### PR TITLE
Add support for I2C bus configuration in order to become compliant fo…

### DIFF
--- a/src/main/java/com/ociweb/iot/hardware/HardwareImpl.java
+++ b/src/main/java/com/ociweb/iot/hardware/HardwareImpl.java
@@ -56,7 +56,7 @@ public abstract class HardwareImpl extends BuilderImpl implements Hardware {
 	private static final HardwareConnection[] EMPTY = new HardwareConnection[0];
 
 	protected boolean configI2C;       //Humidity, LCD need I2C address so..
-	
+	protected int i2cBus;
 	protected long debugI2CRateLastTime;
 
 	protected HardwareConnection[] digitalInputs; //Button, Motion
@@ -106,6 +106,7 @@ public abstract class HardwareImpl extends BuilderImpl implements Hardware {
 		this.i2cBacking = i2cBacking;
 
 		this.configI2C = configI2C; //may be removed.
+		this.i2cBus = -1; // TODO: Should this be initialized in some more complexicated way?
 
 		this.digitalInputs = digitalInputs;
 		this.digitalOutputs = digitalOutputs;
@@ -117,7 +118,7 @@ public abstract class HardwareImpl extends BuilderImpl implements Hardware {
 
 	public static I2CBacking getI2CBacking(byte deviceNum) {
 		try {
-			return new I2CNativeLinuxBacking(deviceNum);
+			return new I2CNativeLinuxBacking().configure(deviceNum);
 		} catch (Throwable t) {
 			//avoid non error case that is used to detect which hardware is running.
 			return null;
@@ -193,12 +194,17 @@ public abstract class HardwareImpl extends BuilderImpl implements Hardware {
 
 
 	public Hardware useI2C() {
-		this.configI2C = true; //TODO: enusre pi grove turns this on at all times, 
+		this.configI2C = true; //TODO: ensure pi grove turns this on at all times,
 		                       //TODO: when this is NOT on do not build the i2c pipes.
 		return this;
 	}
 	
-	
+	public Hardware useI2C(int bus) {
+		this.configI2C = true; //TODO: ensure pi grove turns this on at all times,
+		                       //TODO: when this is NOT on do not build the i2c pipes.
+		this.i2cBus = bus;
+		return this;
+	}
 
 	public abstract HardwarePlatformType getPlatformType();
 	public abstract int read(Port port); //Platform specific

--- a/src/main/java/com/ociweb/iot/hardware/impl/test/TestHardware.java
+++ b/src/main/java/com/ociweb/iot/hardware/impl/test/TestHardware.java
@@ -43,7 +43,7 @@ public class TestHardware extends HardwareImpl {
     private long lastProvidedTime;
     
     public TestHardware(GraphManager gm) {
-        super(gm, new TestI2CBacking());
+        super(gm, new TestI2CBacking().configure((byte) 1));
         //logger.trace("You are running on the test hardware.");
     }
     

--- a/src/main/java/com/ociweb/iot/hardware/impl/test/TestI2CBacking.java
+++ b/src/main/java/com/ociweb/iot/hardware/impl/test/TestI2CBacking.java
@@ -19,7 +19,9 @@ public class TestI2CBacking implements I2CBacking{
     public static final int MAX_BACK_MASK =  MAX_BACK_SIZE-1;
     
     private static final Logger logger = LoggerFactory.getLogger(TestI2CBacking.class);
-    
+
+    private boolean configured = false;
+
     private long[]   lastWriteTime;
     private byte[]   lastWriteAddress;
     private byte[][] lastWriteData;
@@ -52,10 +54,25 @@ public class TestI2CBacking implements I2CBacking{
         responses[address] = data;
         responseLengths[address] = length;
     }
-        
-    
+
+
     @Override
-    public byte[] read(byte address, byte[] target, int length) {
+    public TestI2CBacking configure(byte bus) throws IllegalStateException {
+        if (configured) {
+            throw new IllegalStateException();
+        } else {
+            configured = true;
+        }
+
+        return this;
+    }
+
+    @Override
+    public byte[] read(byte address, byte[] target, int length) throws IllegalStateException {
+        if (!configured) {
+            throw new IllegalStateException();
+        }
+
     	if (null != responses[address]) {    		
     		System.arraycopy(responses[address], 0, target, 0, Math.min(length, responseLengths[address]));
     	} else {
@@ -69,7 +86,10 @@ public class TestI2CBacking implements I2CBacking{
     boolean newLineNeeded = false;
     
     @Override
-    public boolean write(byte address, byte[] message, int length) {
+    public boolean write(byte address, byte[] message, int length) throws IllegalStateException {
+        if (!configured) {
+            throw new IllegalStateException();
+        }
         
         lastWriteCount++;
         lastWriteTime[lastWriteIdx] = System.currentTimeMillis();

--- a/src/main/java/com/ociweb/iot/maker/Hardware.java
+++ b/src/main/java/com/ociweb/iot/maker/Hardware.java
@@ -43,9 +43,18 @@ public interface Hardware extends Builder {
 
    
     /**
-     * Asks this hardware instance to enable I2C communications.
+     * Asks this hardware instance to enable I2C communications on the default I2C bus.
      *
      * @return A reference to this hardware instance.
      */
     Hardware useI2C();
+
+    /**
+     * Asks this hardware instance to enable I2C communications.
+     *
+     * @param bus I2C bus to use.
+     *
+     * @return A reference to this hardware instance.
+     */
+    Hardware useI2C(int bus);
 }

--- a/src/main/java/com/ociweb/pronghorn/iot/i2c/I2CBacking.java
+++ b/src/main/java/com/ociweb/pronghorn/iot/i2c/I2CBacking.java
@@ -8,6 +8,20 @@ package com.ociweb.pronghorn.iot.i2c;
 public interface I2CBacking {
 
     /**
+     * Configures the bus to use on this I2C device. This method
+     * <b>must</b> be invoked before any invocations of
+     * {@link #read(byte, byte[], int)} or {@link #write(byte, byte[], int)},
+     * and it may only be invoked <b>once</b>.
+     *
+     * @param bus I2C bus number to use.
+     *
+     * @throws IllegalStateException if this method is invoked more than once.
+     *
+     * @return This I2CBacking.
+     */
+    I2CBacking configure(byte bus) throws IllegalStateException;
+
+    /**
      * Reads a message from the I2C device at the specified address.
      *
      * @param address Address of the I2C device to read, e.g., "0x32" for a
@@ -16,8 +30,10 @@ public interface I2CBacking {
      *
      * @return Data received from the I2C device, or an empty array if no
      *         data was received.
+     *
+     * @throws IllegalStateException if this method is invoked before {@link #configure(byte)}.
      */
-    byte[] read(byte address, byte[] target, int bufferSize);
+    byte[] read(byte address, byte[] target, int bufferSize) throws IllegalStateException;
 
     /**
      * Writes a message to an I2C device at the specified address.
@@ -25,6 +41,10 @@ public interface I2CBacking {
      * @param address Address of the I2C device to write, e.g., "0x32" for a
      *                GrovePi's LCD RGB backlight.
      * @param message Array of bytes to write to the I2C device.
+     *
+     * @return True if writing the message was successful, and false otherwise.
+     *
+     * @throws IllegalStateException if this method is invoked before {@link #configure(byte)}.
      */
-    boolean write(byte address, byte[] message, int length);
+    boolean write(byte address, byte[] message, int length) throws IllegalStateException;
 }

--- a/src/main/java/com/ociweb/pronghorn/iot/i2c/I2CBacking.java
+++ b/src/main/java/com/ociweb/pronghorn/iot/i2c/I2CBacking.java
@@ -19,7 +19,7 @@ public interface I2CBacking {
      *
      * @return This I2CBacking.
      */
-    I2CBacking configure(byte bus) throws IllegalStateException;
+    I2CBacking configure(byte bus);
 
     /**
      * Reads a message from the I2C device at the specified address.
@@ -33,7 +33,7 @@ public interface I2CBacking {
      *
      * @throws IllegalStateException if this method is invoked before {@link #configure(byte)}.
      */
-    byte[] read(byte address, byte[] target, int bufferSize) throws IllegalStateException;
+    byte[] read(byte address, byte[] target, int bufferSize);
 
     /**
      * Writes a message to an I2C device at the specified address.
@@ -46,5 +46,5 @@ public interface I2CBacking {
      *
      * @throws IllegalStateException if this method is invoked before {@link #configure(byte)}.
      */
-    boolean write(byte address, byte[] message, int length) throws IllegalStateException;
+    boolean write(byte address, byte[] message, int length);
 }

--- a/src/main/java/com/ociweb/pronghorn/iot/i2c/I2CStage.java
+++ b/src/main/java/com/ociweb/pronghorn/iot/i2c/I2CStage.java
@@ -57,7 +57,7 @@ public class I2CStage extends PronghornStage {
         
         
         Thread.currentThread().setPriority(Thread.MAX_PRIORITY);
-        
+
 //            config.beginPinConfiguration();
 //            config.configurePinsForI2C();
 //            config.endPinConfiguration();
@@ -65,7 +65,7 @@ public class I2CStage extends PronghornStage {
         //Figure out which backing to use.
         //TODO: This should probably be chosen by the creator of this stage instead.
         try {
-            backing = new I2CNativeLinuxBacking((byte) 1);
+            backing = new I2CNativeLinuxBacking().configure((byte) 1);
             logger.info("Successfully initialized native Linux I2C backing.");
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
Add basic support for configuring I2C busses. This makes use of runtime exceptions, so it shouldn't create any new requirements for users of the Foglight APIs. This is probably not an ideal long-term solution.