### PR TITLE
Add support for custom trigger rates on the FogRuntime.

### DIFF
--- a/src/main/java/com/ociweb/device/testApp/PiCamTest.java
+++ b/src/main/java/com/ociweb/device/testApp/PiCamTest.java
@@ -39,7 +39,7 @@ public class PiCamTest implements FogApp {
                 images.remove(0);
                 f.delete();
             }
-        });
+        }, 3000);
     }
 
 


### PR DESCRIPTION
This PR adds support for custom trigger rates on the FogRuntime in order to support the Pi camera interval requests. It makes an assumption that custom trigger rates can be created by simply swapping invocations to the builder's trigger rate methods for custom long values.